### PR TITLE
Update container builds to use podman and target linux/amd64 platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # Configuration
 REGISTRY ?= quay.io/insights-onprem
 VERSION ?= latest
-CONTAINER_CMD ?= docker
+CONTAINER_CMD ?= podman
 
 # Image names
 REDIS_IMAGE = $(REGISTRY)/redis-ephemeral:6
@@ -30,7 +30,7 @@ build: build-redis build-ingress build-sources-api-go
 .PHONY: build-redis
 build-redis:
 	@echo "Building Redis ephemeral image..."
-	$(CONTAINER_CMD) build -t $(REDIS_IMAGE) $(REDIS_PATH)
+	$(CONTAINER_CMD) build --platform linux/amd64 -t $(REDIS_IMAGE) $(REDIS_PATH)
 	@echo "Redis image built: $(REDIS_IMAGE)"
 
 .PHONY: build-ingress
@@ -41,7 +41,7 @@ build-ingress:
 		echo "Please ensure insights-ingress-go is cloned in the parent directory"; \
 		exit 1; \
 	fi
-	$(CONTAINER_CMD) build -t $(INGRESS_IMAGE) -f $(INGRESS_PATH)/Dockerfile $(INSIGHTS_INGRESS_GO_PATH)
+	$(CONTAINER_CMD) build --platform linux/amd64 -t $(INGRESS_IMAGE) -f $(INGRESS_PATH)/Dockerfile $(INSIGHTS_INGRESS_GO_PATH)
 	@echo "Insights Ingress image built: $(INGRESS_IMAGE)"
 
 .PHONY: build-sources-api-go
@@ -52,7 +52,7 @@ build-sources-api-go:
 		echo "Please ensure sources-api-go is cloned in the parent directory"; \
 		exit 1; \
 	fi
-	$(CONTAINER_CMD) build -t $(SOURCES_IMAGE) $(SOURCES_API_GO_PATH)
+	$(CONTAINER_CMD) build --platform linux/amd64 -t $(SOURCES_IMAGE) $(SOURCES_API_GO_PATH)
 	@echo "Sources API Go image built: $(SOURCES_IMAGE)"
 
 .PHONY: build-sources-api-go-script
@@ -176,10 +176,10 @@ help:
 	@echo "Configuration:"
 	@echo "  REGISTRY       - Registry to push to (default: quay.io/insights-onprem)"
 	@echo "  VERSION        - Image version tag (default: latest)"
-	@echo "  CONTAINER_CMD  - Container command (default: docker)"
+	@echo "  CONTAINER_CMD  - Container command (default: podman)"
 	@echo ""
 	@echo "Examples:"
 	@echo "  make build"
 	@echo "  REGISTRY_USER=myuser REGISTRY_PASSWORD=mypass make login"
 	@echo "  VERSION=1.0.0 make build-push"
-	@echo "  CONTAINER_CMD=podman make build"
+	@echo "  CONTAINER_CMD=docker make build"

--- a/insights-ingress/Dockerfile
+++ b/insights-ingress/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:latest as builder
+FROM --platform=linux/amd64 registry.access.redhat.com/ubi9/go-toolset:latest as builder
 
 WORKDIR /go/src/app
 
@@ -23,7 +23,7 @@ RUN go get -d ./... && \
 
 RUN cp /go/src/app/insights-ingress-go /usr/bin/
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM --platform=linux/amd64 registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 WORKDIR /
 

--- a/insights-ingress/build.sh
+++ b/insights-ingress/build.sh
@@ -75,6 +75,7 @@ log_info "Dockerfile: $DOCKERFILE_PATH"
 # Build the image
 log_info "Starting Docker build..."
 $CONTAINER_CMD build \
+    --platform linux/amd64 \
     -t "$IMAGE_NAME" \
     -f "$DOCKERFILE_PATH" \
     "$INSIGHTS_INGRESS_GO_PATH"

--- a/redis-ephemeral/Dockerfile
+++ b/redis-ephemeral/Dockerfile
@@ -1,7 +1,7 @@
 # Redis Ephemeral Image for Insights On-Premise
 # Based on Redis 6 with ephemeral storage configuration
 
-FROM redis:6-alpine
+FROM --platform=linux/amd64 redis:6-alpine
 
 # Metadata
 LABEL maintainer="Insights On-Premise Team"


### PR DESCRIPTION
- Set default container command to podman in Makefile
- Add --platform linux/amd64 to all container build commands
- Update insights-ingress, redis-ephemeral, and sources-api-go builds
- Ensure consistent amd64 Linux platform targeting across all services

🤖 Generated with [Claude Code](https://claude.ai/code)